### PR TITLE
Health check

### DIFF
--- a/docker-config/ecs-tasks/app.json
+++ b/docker-config/ecs-tasks/app.json
@@ -35,6 +35,15 @@
                     "hostPort": 587
                 }
             ],
+            "healthCheck": {
+                "command": [
+                    "CMD-SHELL",
+                    "/bin/sh -c 'wget -q -O- http://localhost:8000/api/v1/health-check/ || exit 1'"
+                ],
+                "interval": 30,
+                "timeout": 10,
+                "retries": 3
+            },
             "environment": [
                 {
                     "name": "ENVIRONMENT",

--- a/docker-config/ecs-tasks/app.json
+++ b/docker-config/ecs-tasks/app.json
@@ -123,7 +123,7 @@
         {
             "name": "celery",
             "image": "${IMAGE_NAME}",
-            "essential": false,
+            "essential": true,
             "privileged": false,
             "user": "docker_user",
             "cpu": 30,

--- a/edualert/common/urls.py
+++ b/edualert/common/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+app_name = 'catalogs'
+urlpatterns = [
+    path('health-check/', views.health_check, name='health-check'),
+]

--- a/edualert/common/views/__init__.py
+++ b/edualert/common/views/__init__.py
@@ -1,0 +1,1 @@
+from .health_check import health_check

--- a/edualert/common/views/health_check.py
+++ b/edualert/common/views/health_check.py
@@ -1,0 +1,7 @@
+from django.http import JsonResponse
+
+
+def health_check(request):
+    return JsonResponse({
+        'healthy': True
+    })

--- a/edualert/urls.py
+++ b/edualert/urls.py
@@ -18,6 +18,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 
+from .common import urls as common_urls
 from .profiles import urls as profile_urls
 from .schools import urls as school_urls
 from .subjects import urls as subject_urls
@@ -31,6 +32,7 @@ from .statistics import urls as statistics_urls
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path('api/v1/', include(common_urls, namespace='common')),
     path('api/v1/', include(profile_urls, namespace='users')),
     path('api/v1/', include(school_urls, namespace='schools')),
     path('api/v1/', include(subject_urls, namespace='subjects')),


### PR DESCRIPTION
Added the health-check endpoint which is then used to determine if the API is operational. The check is done every 30 seconds and if there are 3 consecutive failures the task will be considered unhealthy and a new one will be started to replace the current one.

Marked the celery container as essential so in case the container crashes the task will be stopped and a new one will be started to replace the current one.

I didn't find a reliable way to check if celery is inoperational while the container is still running so I didn't add a custom health check for the celery container.